### PR TITLE
Bsv 318 add creator and timestamp to tagjoin

### DIFF
--- a/src/main/java/dk/kb/cop3/backend/crud/database/hibernate/Tag.java
+++ b/src/main/java/dk/kb/cop3/backend/crud/database/hibernate/Tag.java
@@ -1,7 +1,6 @@
 package dk.kb.cop3.backend.crud.database.hibernate;
 
 import java.io.Serializable;
-import java.sql.Timestamp;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -12,7 +11,7 @@ public class Tag implements Serializable{
     private String creator;
     //private String timestamp;
     private String xlink_to;
-    private Set objects = new HashSet(0);
+    private Set tagjoins = new HashSet(0);
     private java.sql.Timestamp timestamp;
 
 
@@ -48,12 +47,12 @@ public class Tag implements Serializable{
         this.xlink_to = xlink_to;
     }
 
-    public Set getObjects() {
-        return objects;
+    public Set getTagjoins() {
+        return tagjoins;
     }
 
-    public void setObjects(Set objects) {
-        this.objects = objects;
+    public void setTagjoins(Set tagjoins) {
+        this.tagjoins = tagjoins;
     }
 
     public  java.sql.Timestamp getTimestamp() {

--- a/src/main/java/dk/kb/cop3/backend/crud/database/hibernate/TagJoin.java
+++ b/src/main/java/dk/kb/cop3/backend/crud/database/hibernate/TagJoin.java
@@ -1,0 +1,45 @@
+package dk.kb.cop3.backend.crud.database.hibernate;
+
+import java.io.Serializable;
+import java.sql.Timestamp;
+
+public class TagJoin implements Serializable {
+
+    private Object object;
+    private Tag tag;
+
+    public Object getObject() {
+        return object;
+    }
+
+    public void setObject(Object object) {
+        this.object = object;
+    }
+
+    public Tag getTag() {
+        return tag;
+    }
+
+    public void setTag(Tag tag) {
+        this.tag = tag;
+    }
+
+    private String creator;
+    private java.sql.Timestamp timestamp;
+
+    public String getCreator() {
+        return creator;
+    }
+
+    public void setCreator(String creator) {
+        this.creator = creator;
+    }
+
+    public Timestamp getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Timestamp timestamp) {
+        this.timestamp = timestamp;
+    }
+}

--- a/src/main/java/dk/kb/cop3/backend/migrate/MigrateDB.java
+++ b/src/main/java/dk/kb/cop3/backend/migrate/MigrateDB.java
@@ -12,6 +12,7 @@ public class MigrateDB {
         MigrateUsers.main(args);
         MigrateAreasInDk.main(args);
         MigrateObjects.main(args);
+        MigrateTagJoins.main(args);
         MigrateComments.main(args);
     }
 }

--- a/src/main/java/dk/kb/cop3/backend/migrate/MigrateTagJoins.java
+++ b/src/main/java/dk/kb/cop3/backend/migrate/MigrateTagJoins.java
@@ -1,0 +1,52 @@
+package dk.kb.cop3.backend.migrate;
+
+import dk.kb.cop3.backend.crud.database.hibernate.Object;
+import dk.kb.cop3.backend.crud.database.hibernate.Tag;
+import dk.kb.cop3.backend.crud.database.hibernate.TagJoin;
+import dk.kb.cop3.backend.migrate.hibernate.TagJoinOracle;
+import dk.kb.cop3.backend.migrate.hibernate.TagOracle;
+import org.apache.log4j.Logger;
+import org.hibernate.Session;
+import org.hibernate.SessionFactory;
+import org.hibernate.Transaction;
+import org.hibernate.cfg.Configuration;
+
+import java.util.List;
+
+public class MigrateTagJoins {
+    private static final Logger logger = Logger.getLogger(MigrateTagJoins.class);
+
+
+    public static void main(String[] args) {
+        Session oraSession = MigrationUtils.getOracleSession();
+
+        SessionFactory psqlSessfac = new Configuration().configure("hibernate.cfg.xml")
+                .buildSessionFactory();
+
+        Session psqlSession = psqlSessfac.openSession();
+
+        List<TagJoinOracle> tagJoinOracles = oraSession.createQuery("from dk.kb.cop3.backend.migrate.hibernate.TagJoinOracle where oid='/images/luftfo/2011/maj/luftfoto/object72762'").list();
+        tagJoinOracles.stream().forEach(tagJoinOracle -> {
+            TagJoin tagJoin = new TagJoin();
+            Object object = psqlSession.get(Object.class,tagJoinOracle.getOid());
+            Tag tag = psqlSession.get(Tag.class,tagJoinOracle.getTid());
+            if (object != null && tag !=null) {
+                tagJoin.setTag(tag);
+                tagJoin.setObject(object);
+                tagJoin.setCreator(tagJoinOracle.getCreator());
+                tagJoin.setTimestamp(tagJoinOracle.getTimestamp());
+                try {
+                    Transaction tx = psqlSession.beginTransaction();
+                    psqlSession.save(tagJoin);
+                    tx.commit();
+                } catch (Exception ex) {
+                    logger.error("error saving tagjoin ",ex);
+                }
+            } else {
+                logger.error("object or tag not migrated "+tagJoinOracle.toString());
+            }
+        });
+
+
+    }
+}

--- a/src/main/java/dk/kb/cop3/backend/migrate/MigrateTagJoins.java
+++ b/src/main/java/dk/kb/cop3/backend/migrate/MigrateTagJoins.java
@@ -25,7 +25,7 @@ public class MigrateTagJoins {
 
         Session psqlSession = psqlSessfac.openSession();
 
-        List<TagJoinOracle> tagJoinOracles = oraSession.createQuery("from dk.kb.cop3.backend.migrate.hibernate.TagJoinOracle where oid='/images/luftfo/2011/maj/luftfoto/object72762'").list();
+        List<TagJoinOracle> tagJoinOracles = oraSession.createQuery("from dk.kb.cop3.backend.migrate.hibernate.TagJoinOracle").list();
         tagJoinOracles.stream().forEach(tagJoinOracle -> {
             TagJoin tagJoin = new TagJoin();
             Object object = psqlSession.get(Object.class,tagJoinOracle.getOid());

--- a/src/main/java/dk/kb/cop3/backend/migrate/ObjectConverter.java
+++ b/src/main/java/dk/kb/cop3/backend/migrate/ObjectConverter.java
@@ -188,9 +188,9 @@ public class ObjectConverter {
         object.setLikes(oraObject.getLikes());
         object.setLikes(oraObject.getLikes());
 
-        object.setKeywords((Set<Tag>) oraObject.getKeywords().stream()
-                .map(oraTag-> {return convertTag((TagOracle) oraTag);})
-                        .collect(Collectors.toSet()));
+//        object.setKeywords((Set<Tag>) oraObject.getKeywords().stream()
+//                .map(oraTag-> {return convertTag((TagOracle) oraTag);})
+//                        .collect(Collectors.toSet()));
 
         object.setCategories((Set<Category>) oraObject.getCategories().stream()
                 .map(oraCategory->{return convertCategory((CategoryOracle) oraCategory);})

--- a/src/main/java/dk/kb/cop3/backend/migrate/hibernate/TagJoinOracle.java
+++ b/src/main/java/dk/kb/cop3/backend/migrate/hibernate/TagJoinOracle.java
@@ -1,0 +1,56 @@
+package dk.kb.cop3.backend.migrate.hibernate;
+
+import dk.kb.cop3.backend.crud.database.hibernate.Object;
+
+import java.io.Serializable;
+import java.sql.Timestamp;
+
+public class TagJoinOracle implements Serializable {
+
+    private String tid;
+    private String oid;
+    private String creator;
+    private java.sql.Timestamp timestamp;
+
+    public String getTid() {
+        return tid;
+    }
+
+    public void setTid(String tid) {
+        this.tid = tid;
+    }
+
+    public String getOid() {
+        return oid;
+    }
+
+    public void setOid(String oid) {
+        this.oid = oid;
+    }
+
+    public String getCreator() {
+        return creator;
+    }
+
+    public void setCreator(String creator) {
+        this.creator = creator;
+    }
+
+    public Timestamp getTimestamp() {
+        return timestamp;
+    }
+
+    public void setTimestamp(Timestamp timestamp) {
+        this.timestamp = timestamp;
+    }
+
+    @Override
+    public String toString() {
+        return "TagJoinOracle{" +
+                "tid='" + tid + '\'' +
+                ", oid='" + oid + '\'' +
+                ", creator='" + creator + '\'' +
+                ", timestamp=" + timestamp +
+                '}';
+    }
+}

--- a/src/main/resources/dk/kb/cop3/backend/crud/database/hibernate/Tag.hbm.xml
+++ b/src/main/resources/dk/kb/cop3/backend/crud/database/hibernate/Tag.hbm.xml
@@ -24,16 +24,9 @@
             <column name="TIMESTAMP" not-null="true" />
         </property>
 
-        <set name="objects" table="TAG_JOIN" inverse="false" lazy="true" fetch="select">
-            <key>
-                <column name="TID" length="1024" not-null="true" />
-            </key>
-            <many-to-many entity-name="dk.kb.cop3.backend.crud.database.hibernate.Object">
-                <column name="OID" length="1024" not-null="true" />
-            </many-to-many>
-
-
-
+        <set name="tagjoins" table="TAG_JOIN" lazy="true" fetch="select">
+            <key column="tid"/>
+            <one-to-many class="dk.kb.cop3.backend.crud.database.hibernate.TagJoin" />
         </set>
     </class>
 </hibernate-mapping>

--- a/src/main/resources/dk/kb/cop3/backend/crud/database/hibernate/TagJoin.hbm.xml
+++ b/src/main/resources/dk/kb/cop3/backend/crud/database/hibernate/TagJoin.hbm.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+        "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<!-- Generated Apr 27, 2011 3:35:31 PM by Hibernate Tools 3.3.0.GA -->
+<hibernate-mapping>
+    <class name="dk.kb.cop3.backend.crud.database.hibernate.TagJoin" table="TAG_JOIN">
+        <composite-id>
+            <key-many-to-one name="tag" class="dk.kb.cop3.backend.crud.database.hibernate.Tag" column="tid"/>
+            <key-many-to-one name="object" class="dk.kb.cop3.backend.crud.database.hibernate.Object" column="oid"/>
+        </composite-id>
+        <property name="creator" type="string">
+            <column name="CREATOR" length="100" not-null="true" />
+        </property>
+        <property name="timestamp" type="timestamp">
+            <column name="TIMESTAMP" not-null="true" />
+        </property>
+    </class>
+</hibernate-mapping>

--- a/src/main/resources/hibernate.cfg.xml
+++ b/src/main/resources/hibernate.cfg.xml
@@ -24,6 +24,7 @@
         <mapping resource="dk/kb/cop3/backend/crud/database/hibernate/Edition.hbm.xml"/>
         <mapping resource="dk/kb/cop3/backend/crud/database/hibernate/Category.hbm.xml"/>
         <mapping resource="dk/kb/cop3/backend/crud/database/hibernate/Tag.hbm.xml"/>
+        <mapping resource="dk/kb/cop3/backend/crud/database/hibernate/TagJoin.hbm.xml"/>
         <mapping resource="dk/kb/cop3/backend/crud/database/hibernate/XLink.hbm.xml"/>
         <mapping resource="dk/kb/cop3/backend/crud/database/hibernate/Comment.hbm.xml"/>
         <mapping resource="dk/kb/cop3/backend/crud/database/hibernate/Type.hbm.xml"/>

--- a/src/main/resources/oracle/dk/kb/cop2/backend/crud/database/hibernate/TagJoin.hbm.xml
+++ b/src/main/resources/oracle/dk/kb/cop2/backend/crud/database/hibernate/TagJoin.hbm.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0"?>
+<!DOCTYPE hibernate-mapping PUBLIC "-//Hibernate/Hibernate Mapping DTD 3.0//EN"
+        "http://www.hibernate.org/dtd/hibernate-mapping-3.0.dtd">
+<!-- Generated Apr 27, 2011 3:35:31 PM by Hibernate Tools 3.3.0.GA -->
+<hibernate-mapping>
+    <class name="dk.kb.cop3.backend.migrate.hibernate.TagJoinOracle" table="TAG_JOIN">
+        <composite-id>
+            <key-property name="tid" column="tid"></key-property>
+            <key-property name="oid" column="oid"></key-property>
+        </composite-id>
+        <property name="creator" type="string">
+            <column name="CREATOR" length="100" not-null="true" />
+        </property>
+        <property name="timestamp" type="timestamp">
+            <column name="TIMESTAMP" not-null="true" />
+        </property>
+    </class>
+</hibernate-mapping>

--- a/src/main/resources/oracle/hibernate-oracle.cfg.xml
+++ b/src/main/resources/oracle/hibernate-oracle.cfg.xml
@@ -24,6 +24,7 @@
         <mapping resource="oracle/dk/kb/cop2/backend/crud/database/hibernate/Edition.hbm.xml"/>
         <mapping resource="oracle/dk/kb/cop2/backend/crud/database/hibernate/Category.hbm.xml"/>
         <mapping resource="oracle/dk/kb/cop2/backend/crud/database/hibernate/Tag.hbm.xml"/>
+        <mapping resource="oracle/dk/kb/cop2/backend/crud/database/hibernate/TagJoin.hbm.xml"/>
         <mapping resource="oracle/dk/kb/cop2/backend/crud/database/hibernate/XLink.hbm.xml"/>
         <mapping resource="oracle/dk/kb/cop2/backend/crud/database/hibernate/Comment.hbm.xml"/>
         <mapping resource="oracle/dk/kb/cop2/backend/crud/database/hibernate/Type.hbm.xml"/>


### PR DESCRIPTION
har tilføjet de to felter til tagjoin tabellen i postgres

har tilføjet et ekstra migrate script til at migrere tagjoins fra oracle til postgres. Det skal køres efter objects og tags er blevet migreret